### PR TITLE
[iOS] run clearBadge logic on main thread to prevent xcode warnings

### DIFF
--- a/src/ios/PushPlugin.m
+++ b/src/ios/PushPlugin.m
@@ -225,7 +225,9 @@
             } else {
                 NSLog(@"PushPlugin.register: setting badge to true");
                 clearBadge = YES;
-                [[UIApplication sharedApplication] setApplicationIconBadgeNumber:0];
+                dispatch_async(dispatch_get_main_queue(), ^{
+                    [[UIApplication sharedApplication] setApplicationIconBadgeNumber:0];
+                });
             }
             NSLog(@"PushPlugin.register: clear badge is set to %d", clearBadge);
 


### PR DESCRIPTION
run clearBadge logic on main thread to prevent xcode warnings